### PR TITLE
switch to inheriting from StandardError

### DIFF
--- a/lib/aweber.rb
+++ b/lib/aweber.rb
@@ -57,12 +57,12 @@ module AWeber
   @api_endpoint  = "https://api.aweber.com"
   @auth_endpoint = "https://auth.aweber.com"
   
-  class OAuthError < Exception; end
-  class NotFoundError < Exception; end
-  class UnknownRequestError < Exception; end
-  class RateLimitError < Exception; end
-  class ForbiddenRequestError < Exception; end
-  class CreationError < Exception; end
+  class OAuthError < StandardError; end
+  class NotFoundError < StandardError; end
+  class UnknownRequestError < StandardError; end
+  class RateLimitError < StandardError; end
+  class ForbiddenRequestError < StandardError; end
+  class CreationError < StandardError; end
 end
 
 $LOAD_PATH << File.dirname(__FILE__) unless $LOAD_PATH.include?(File.dirname(__FILE__))


### PR DESCRIPTION
( fixes #26 )

as [extensively documented elsewhere](http://stackoverflow.com/questions/10048173/why-is-it-bad-style-to-rescue-exception-e-in-ruby), catching or extending `Exception` in ruby is a bad practice.
